### PR TITLE
wtk data endpoint consolidation for average wind speed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - ./windwatts-api:/app
     command: >
-      uvicorn main:app --host 0.0.0.0 --reload
+      uvicorn app.main:app --host 0.0.0.0 --reload
 
   windwatts-ui:
     build:

--- a/windwatts-api/.gitignore
+++ b/windwatts-api/.gitignore
@@ -1,4 +1,5 @@
 .venv
 __pycache__
-wtk_data.db
-config/*.json
+app/db/wtk_data.db
+app/config/*.json
+!app/config/sample_windwatts_data_config.json

--- a/windwatts-api/Dockerfile
+++ b/windwatts-api/Dockerfile
@@ -19,7 +19,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Download and install windwatts_data.whl from s3
-ARG WINDWATTS_DATA_VERSION=1.0.1.1
+ARG WINDWATTS_DATA_VERSION=1.0.0
 ARG WINDWATTS_DATA_URL
 ARG WINDWATTS_DATA_FILE=windwatts_data-${WINDWATTS_DATA_VERSION}-py3-none-any.whl
 RUN curl -o /tmp/windwatts_data-${WINDWATTS_DATA_VERSION}-py3-none-any.whl ${WINDWATTS_DATA_URL}${WINDWATTS_DATA_FILE} && \

--- a/windwatts-api/app/config/sample_windwatts_data_config.json
+++ b/windwatts-api/app/config/sample_windwatts_data_config.json
@@ -1,0 +1,10 @@
+{
+  "region_name": "us-east-1",
+  "bucket_name": "sample-bucket",
+  "database": "sample_database",
+  "output_location": "s3://sample-output-location/",
+  "output_bucket": "sample-output-bucket",
+  "athena_table_name": "sample_table",
+  "alt_athena_table_name": "sample_alt_table",
+  "athena_workgroup": "sample_workgroup"
+}

--- a/windwatts-api/app/controllers/era5_data_controller.py
+++ b/windwatts-api/app/controllers/era5_data_controller.py
@@ -1,0 +1,12 @@
+'''
+Placeholder for ERA5 data controller
+'''
+
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+@router.get("/windspeed", summary="Retrieve global wind speed - ERA5 data")
+def get_windspeed(lat: float, lng: float, height: int):
+    return {"message": "This is a placeholder for the ERA5 data controller"}

--- a/windwatts-api/app/controllers/wind_data_controller.py
+++ b/windwatts-api/app/controllers/wind_data_controller.py
@@ -1,18 +1,15 @@
 from fastapi import APIRouter, HTTPException
 
 # commented out the data functions until I can get local athena_config working
-'''
 from app.config_manager import ConfigManager
 from app.data_fetchers.s3_data_fetcher import S3DataFetcher
 from app.data_fetchers.athena_data_fetcher import AthenaDataFetcher
 from app.data_fetchers.database_data_fetcher import DatabaseDataFetcher
 from app.data_fetchers.data_fetcher_router import DataFetcherRouter
 from app.database_manager import DatabaseManager
-'''
 
 router = APIRouter()
 
-'''
 # Initialize ConfigManager
 config_manager = ConfigManager(
     secret_arn_env_var="WINDWATTS_DATA_CONFIG_SECRET_ARN",
@@ -30,7 +27,7 @@ data_fetcher_router = DataFetcherRouter()
 data_fetcher_router.register_fetcher("database", db_data_fetcher)
 data_fetcher_router.register_fetcher("s3", s3_data_fetcher)
 data_fetcher_router.register_fetcher("athena", athena_data_fetcher)
-'''
+
 
 @router.get("/windspeed", summary="Retrieve wind speed data")
 def get_windspeed(lat: float, lng: float):
@@ -61,7 +58,7 @@ def get_windspeed(lat: float, lng: float):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.get("/wtk-data", summary="Retrieve WTK data")
+@router.get("/wtk-data/windspeed", summary="Retrieve WTK data")
 def get_wtk_data(lat: float, lng: float, height: int, source: str = "athena"):
     try:
         params = {
@@ -70,7 +67,7 @@ def get_wtk_data(lat: float, lng: float, height: int, source: str = "athena"):
             "height": height,
         }
         data = params
-        # data = data_fetcher_router.fetch_data(params, source=source)
+        data = data_fetcher_router.fetch_data(params, source=source)
         if data is None:
             raise HTTPException(status_code=404, detail="Data not found")
         return data

--- a/windwatts-api/app/controllers/wtk_data_controller.py
+++ b/windwatts-api/app/controllers/wtk_data_controller.py
@@ -13,7 +13,7 @@ router = APIRouter()
 # Initialize ConfigManager
 config_manager = ConfigManager(
     secret_arn_env_var="WINDWATTS_DATA_CONFIG_SECRET_ARN",
-    local_config_path="./config/windwatts_data_config.json")
+    local_config_path="../config/windwatts_data_config.json") # replace with YOUR local config path
 athena_config = config_manager.get_config()
 
 # Initialize DataFetchers

--- a/windwatts-api/app/controllers/wtk_data_controller.py
+++ b/windwatts-api/app/controllers/wtk_data_controller.py
@@ -32,7 +32,8 @@ data_fetcher_router.register_fetcher("athena", athena_data_fetcher)
 wind_speed_avg_types = ["global", "monthly", "monthly"]
 
 
-@router.get("/windspeed/{avg_type}", summary="Retrieve wind speed - wtk data")
+@router.get("/windspeed/{avg_type}", summary="Retrieve wind speed with avg type - wtk data")
+@router.get("/windspeed", summary="Retrieve wind speed with default global avg - wtk data")
 def get_windspeed(lat: float, lng: float, height: int, avg_type: str = 'global', source: str = "athena"):
     '''
     Retrieve wind speed data from the WTK database.

--- a/windwatts-api/app/controllers/wtk_data_controller.py
+++ b/windwatts-api/app/controllers/wtk_data_controller.py
@@ -13,7 +13,7 @@ router = APIRouter()
 # Initialize ConfigManager
 config_manager = ConfigManager(
     secret_arn_env_var="WINDWATTS_DATA_CONFIG_SECRET_ARN",
-    local_config_path="../config/windwatts_data_config.json") # replace with YOUR local config path
+    local_config_path="./app/config/windwatts_data_config.json") # replace with YOUR local config path
 athena_config = config_manager.get_config()
 
 # Initialize DataFetchers

--- a/windwatts-api/app/data_fetchers/athena_data_fetcher.py
+++ b/windwatts-api/app/data_fetchers/athena_data_fetcher.py
@@ -1,5 +1,5 @@
 from .abstract_data_fetcher import WTKDataFetcher
-from windwatts_data import WTKLedClient1224
+from windwatts_data import WindwattsWTKClient
 
 class AthenaDataFetcher(WTKDataFetcher):
     def __init__(self, athena_config):
@@ -9,9 +9,9 @@ class AthenaDataFetcher(WTKDataFetcher):
         Args:
             athena_config (str): Path to the Athena configuration file.
         """
-        self.wtk_client = WTKLedClient1224(config_path=athena_config)
+        self.wtk_client = WindwattsWTKClient(config_path=athena_config)
 
-    def fetch_data(self, lat: float, lng: float, height: int):
+    def fetch_data(self, lat: float, lng: float, height: int, avg_type: str = 'global'):
         """
         Fetch data from Athena using the WTKLedClient.
 
@@ -19,9 +19,17 @@ class AthenaDataFetcher(WTKDataFetcher):
             lat (float): Latitude of the location.
             lng (float): Longitude of the location.
             height (int): Height in meters.
+            avg_type (str): Type of average to fetch. Can be 'global', 'yearly' or 'monthly'. Defaults to 'global'.
 
         Returns:
             dict: A dictionary containing the fetched data.
         """
-        filtered_data = self.wtk_client.fetch_windwatts_data(lat=lat, long=lng, height=height)
+        filtered_data = None
+        if avg_type == 'global':
+            filtered_data = self.wtk_client.fetch_global_avg_at_height(lat=lat, long=lng, height=height)
+        elif avg_type == 'yearly':
+            filtered_data = self.wtk_client.fetch_yearly_avg_at_height(lat=lat, long=lng, height=height)
+        elif avg_type == 'monthly':
+            filtered_data = self.wtk_client.fetch_monthly_avg_at_height(lat=lat, long=lng, height=height)
+        
         return filtered_data

--- a/windwatts-api/app/main.py
+++ b/windwatts-api/app/main.py
@@ -18,7 +18,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(wind_data_router, tags=["winddata"])
+app.include_router(wind_data_router, prefix="/wtk-data", tags=["wtk-database"])
 app.include_router(random_router, prefix="/random", tags=["random"])
 
 @app.get("/healthcheck")

--- a/windwatts-api/app/main.py
+++ b/windwatts-api/app/main.py
@@ -2,7 +2,8 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from mangum import Mangum
 from app.controllers.random_controller import router as random_router
-from app.controllers.wind_data_controller import router as wind_data_router
+from app.controllers.wtk_data_controller import router as wtk_data_router
+from app.controllers.era5_data_controller import router as era5_data_router
 
 app = FastAPI()
 
@@ -18,7 +19,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(wind_data_router, prefix="/wtk-data", tags=["wtk-database"])
+app.include_router(wtk_data_router, prefix="/wtk-data", tags=["wtk-database"])
+app.include_router(era5_data_router, prefix="/era5-data", tags=["era5-database"])
 app.include_router(random_router, prefix="/random", tags=["random"])
 
 @app.get("/healthcheck")

--- a/windwatts-ui/src/components/Layout.jsx
+++ b/windwatts-ui/src/components/Layout.jsx
@@ -97,7 +97,7 @@ function Layout() {
               openResults={openResults}
               handleClose={handleCloseResults}
               currentPosition={currentPosition}
-              hubHeight={hubHeight}
+              height={hubHeight}
               powerCurve={powerCurve}
             />
           </Box>

--- a/windwatts-ui/src/components/Layout.jsx
+++ b/windwatts-ui/src/components/Layout.jsx
@@ -116,7 +116,7 @@ function Layout() {
         openResults={openResults}
         handleClose={handleCloseResults}
         currentPosition={currentPosition}
-        hubHeight={hubHeight}
+        height={hubHeight}
         powerCurve={powerCurve}
       />
     </Box>

--- a/windwatts-ui/src/components/ResultCard.jsx
+++ b/windwatts-ui/src/components/ResultCard.jsx
@@ -11,7 +11,24 @@ import {
 import PropTypes from "prop-types";
 
 const ResultCard = ({
-  data = {
+  windspeed,
+  energy,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const windspeedData = {
+    title: "Wind Resource",
+    subheader: "Details about wind resources",
+    data: `we found average ${windspeed} m/s resources.`,
+    details: [
+      "Additional details about wind resources:",
+      "Low wind resource refers to wind speeds below 3.00 m/s.",
+      "Moderate wind resource refers to wind speeds between 3.00 m/s and 5.00 m/s.",
+      "High wind resource refers to wind speeds above 5.00 m/s.",
+    ],
+  }
+  
+  const windresourceData = {
     title: "Wind Resource",
     subheader: "Details about wind resources",
     data: "This section provides information about wind resources.",
@@ -21,9 +38,7 @@ const ResultCard = ({
       "Moderate wind resource refers to wind speeds between 3.00 m/s and 5.00 m/s.",
       "High wind resource refers to wind speeds above 5.00 m/s.",
     ],
-  },
-}) => {
-  const [expanded, setExpanded] = useState(false);
+  }
 
   const handleExpandClick = () => {
     setExpanded(!expanded);
@@ -32,13 +47,13 @@ const ResultCard = ({
   return (
     <Card sx={{ margin: "auto", mt: 5 }}>
       <CardHeader
-        title={data.title}
-        subheader={data.subheader}
+        title={windspeedData.title}
+        subheader={windspeedData.subheader}
         sx={{ bgcolor: "var(--color-light)" }}
       />
       <CardContent>
         <Typography variant="body2" color="text.secondary">
-          {data.data}
+          {windspeedData.data}
         </Typography>
       </CardContent>
       <CardActions>
@@ -52,7 +67,7 @@ const ResultCard = ({
       </CardActions>
       <Collapse in={expanded} timeout="auto" unmountOnExit>
         <CardContent>
-          {data.details.map((detail, index) => (
+          {windspeedData.details.map((detail, index) => (
             <Typography key={"result_detail" + index}>{detail}</Typography>
           ))}
         </CardContent>

--- a/windwatts-ui/src/components/RightPane.jsx
+++ b/windwatts-ui/src/components/RightPane.jsx
@@ -13,16 +13,16 @@ import PropTypes from "prop-types";
 import ResultCard from "./ResultCard";
 import { getWindResourceDataByCoordinates } from "../services/api";
 
-const RightPane = ({ currentPosition, hubHeight, powerCurve }) => {
+const RightPane = ({ currentPosition, height, powerCurve }) => {
   const { lat, lng } = currentPosition ?? {};
-  const shouldFetch = lat && lng;
+  const shouldFetch = lat && lng & height;
   
   const {
     isLoading,
     data: resultCardData,
     error,
   } = useSWR(
-    shouldFetch? { lat, lng } : null,
+    shouldFetch? { lat, lng, height } : null,
     getWindResourceDataByCoordinates
   ); // cache key for this lat, lng; see https://swr.vercel.app/docs/arguments#passing-objects
 
@@ -36,7 +36,7 @@ const RightPane = ({ currentPosition, hubHeight, powerCurve }) => {
     },
     {
       title: "Selected hub height",
-      data: hubHeight ? `${hubHeight} meters` : "Not selected",
+      data: height ? `${height} meters` : "Not selected",
     },
     {
       title: "Selected power curve",
@@ -109,12 +109,11 @@ const RightPane = ({ currentPosition, hubHeight, powerCurve }) => {
               <Skeleton sx={{ marginTop: 5 }} variant="rounded" height={190} />
             </Box>
           ) : resultCardData ? (
-            resultCardData.winddataexample.map((data, index) => (
-              <Grid2 key={"result_card_" + index}>
-                <ResultCard data={data} />
-              </Grid2>
-            ))
-          ) : null}
+            <Grid2 key={"result_card_"}>
+              <ResultCard windspeed={resultCardData.windspeed} />
+            </Grid2>
+          ) : null
+          }
         </Stack>
         <Typography variant="body2" color="textSecondary" marginTop={2}>
           Disclaimer: This summary represents a PRELIMINARY analysis. Research
@@ -134,7 +133,7 @@ RightPane.propTypes = {
     lat: PropTypes.number,
     lng: PropTypes.number,
   }),
-  hubHeight: PropTypes.number,
+  height: PropTypes.number,
   powerCurve: PropTypes.number,
 };
 

--- a/windwatts-ui/src/components/RightPane.jsx
+++ b/windwatts-ui/src/components/RightPane.jsx
@@ -110,7 +110,7 @@ const RightPane = ({ currentPosition, height, powerCurve }) => {
             </Box>
           ) : resultCardData ? (
             <Grid2 key={"result_card_"}>
-              <ResultCard windspeed={resultCardData.windspeed} />
+              <ResultCard windspeed={resultCardData.global_avg} />
             </Grid2>
           ) : null
           }

--- a/windwatts-ui/src/services/api.js
+++ b/windwatts-ui/src/services/api.js
@@ -44,10 +44,10 @@ export const getWindResourceData = async (windResource) => {
   };
 };
 
-export const getWindResourceDataByCoordinates = async ({ lat, lng }) => {
-  console.log("getWindResourceDataByCoordinates for " + lat + ", " + lng);
+export const getWindResourceDataByCoordinates = async ({ lat, lng, height }) => {
+  console.log("getWindResourceDataByCoordinates for " + lat + ", " + lng + ", " + height);
   // example implementation that works locally when the backend fastapi server is running
-  const url = `/api/windspeed?lat=${lat}&lng=${lng}`;
+  const url = `/api/wtk-data/windspeed?lat=${lat}&lng=${lng}&height=${height}`;
   const options = {
     method: "GET",
     headers: {


### PR DESCRIPTION
this connects to #42 and #31 

- consolidate the endpooint for windspeed, now `api/wtk-data/windspeed/${avg_type}?lat=${lat}&lng=${lng}&height=${height}&source=${source}` default avg_type is `global` and source is `athena`. The return type for global is `{"global_avg": value}`.
- add a sample config file for windwatts-data athena package
- add a era5 controller for new database
- update package to the changes in new version of wind-data package