### PR TITLE
config_manager accepts env vars to config file

### DIFF
--- a/windwatts-api/app/config_manager.py
+++ b/windwatts-api/app/config_manager.py
@@ -17,8 +17,7 @@ class ConfigManager:
 
     def get_config(self) -> str:
         """
-        Retrieve the secret from AWS Secrets Manager or the local configuration file.
-
+        Retrieve the secret from AWS Secrets Manager, environment variables, or the local configuration file.
         :return: The path to the configuration file.
         """
         # Try to retrieve the secret from AWS Secrets Manager
@@ -35,10 +34,70 @@ class ConfigManager:
                 return temp_file.name
             except self.client.exceptions.ClientError as e:
                 print(f"Unable to retrieve secret: {e}")
-        
+
+        # Try to retrieve config from environment variables
+        env_config = self._get_config_from_env()
+        if env_config:
+            temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
+            with open(temp_file.name, 'w') as f:
+                json.dump(env_config, f)
+            print("Config loaded from environment variables.")
+            return temp_file.name
+
         # Fallback: return the path to the local configuration file
         if self.local_config_path and os.path.exists(self.local_config_path):
             print("Local configuration file found.")
             return self.local_config_path
         else:
-            raise FileNotFoundError("Local configuration file not found and unable to retrieve secret from AWS Secrets Manager.")
+            raise FileNotFoundError("Local configuration file not found and unable to retrieve secret from AWS Secrets Manager or environment variables.")
+
+    def _get_config_from_env(self):
+        """
+        Retrieve configuration from environment variables.
+        Dynamically scan env vars with SOURCES_<SOURCE>_FIELD_NAME pattern for `sources` configuration.
+        """
+        # Top-level keys
+        region_name = os.getenv('REGION_NAME')
+        output_location = os.getenv('OUTPUT_LOCATION')
+        output_bucket = os.getenv('OUTPUT_BUCKET')
+        database = os.getenv('DATABASE')
+        athena_workgroup = os.getenv('ATHENA_WORKGROUP')
+
+        # Scan for all SOURCES_<SOURCE>_FIELD_NAME env vars
+        sources = {}
+        prefix = 'SOURCES_'
+        suffixes = ['_BUCKET_NAME', '_ATHENA_TABLE_NAME', '_ALT_ATHENA_TABLE_NAME']
+        env = os.environ
+        source_fields = {}
+        for key, value in env.items():
+            if key.startswith(prefix):
+                rest = key[len(prefix):]
+                for suffix in suffixes:
+                    if rest.endswith(suffix):
+                        source = rest[:-len(suffix)].lower()
+                        field = suffix[1:].lower()  # e.g. 'bucket_name'
+                        if source not in source_fields:
+                            source_fields[source] = {}
+                        source_fields[source][field] = value
+        # Package the sources with required fields into `sources`
+        for source, fields in source_fields.items():
+            if 'bucket_name' in fields and 'athena_table_name' in fields:
+                if 'alt_athena_table_name' not in fields:
+                    fields['alt_athena_table_name'] = ''
+                sources[source] = {
+                    'bucket_name': fields['bucket_name'],
+                    'athena_table_name': fields['athena_table_name'],
+                    'alt_athena_table_name': fields['alt_athena_table_name']
+                }
+        # check if all keys have been set
+        if all([region_name, output_location, output_bucket, database, athena_workgroup]) and sources:
+            return {
+                'region_name': region_name,
+                'output_location': output_location,
+                'output_bucket': output_bucket,
+                'database': database,
+                'athena_workgroup': athena_workgroup,
+                'sources': sources
+            }
+        else:
+            return None

--- a/windwatts-api/app/config_manager.py
+++ b/windwatts-api/app/config_manager.py
@@ -29,6 +29,7 @@ class ConfigManager:
                 
                 # Save the secret to a temporary file
                 temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
+                temp_file.close()
                 with open(temp_file.name, 'w') as f:
                     json.dump(config_data, f)
                 return temp_file.name
@@ -39,6 +40,7 @@ class ConfigManager:
         env_config = self._get_config_from_env()
         if env_config:
             temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
+            temp_file.close()
             with open(temp_file.name, 'w') as f:
                 json.dump(env_config, f)
             print("Config loaded from environment variables.")

--- a/windwatts-api/tests/test_config_manager_env.py
+++ b/windwatts-api/tests/test_config_manager_env.py
@@ -1,0 +1,28 @@
+import os
+from app.config_manager import ConfigManager
+
+# Set required top-level environment variables
+os.environ['REGION_NAME'] = 'us-west-2'
+os.environ['OUTPUT_LOCATION'] = 's3://test-bucket/'
+os.environ['OUTPUT_BUCKET'] = 'test-bucket'
+os.environ['DATABASE'] = 'test_database'
+os.environ['ATHENA_WORKGROUP'] = 'test_workgroup'
+
+# Set environment variables for two sources: wtk and era5
+os.environ['SOURCES_WTK_BUCKET_NAME'] = 'wtk-bucket'
+os.environ['SOURCES_WTK_ATHENA_TABLE_NAME'] = 'wtk_table'
+os.environ['SOURCES_WTK_ALT_ATHENA_TABLE_NAME'] = 'wtk_alt_table'
+os.environ['SOURCES_ERA5_BUCKET_NAME'] = 'era5-bucket'
+os.environ['SOURCES_ERA5_ATHENA_TABLE_NAME'] = 'era5_table'
+# alt_athena_table_name is optional
+
+# Instantiate ConfigManager (no secret ARN, no local file)
+cm = ConfigManager(secret_arn_env_var='DUMMY_SECRET_ARN', local_config_path=None)
+
+# Get config path
+config_path = cm.get_config()
+print(f"\nGenerated config file path: {config_path}\n")
+
+# Print the contents for verification
+with open(config_path) as f:
+    print(f.read())


### PR DESCRIPTION
#85 

- to avoid retrieve configs as a json file from ssm or arn, set up mechanism to allow inject secrets/configs as env vars and parse them and package into a temp json file.
- allow dynamically scan env vars for sources.
- add a test file to confirm success parsing and returning the path to temp file.