### PR TITLE
Feat/loss assumption

### DIFF
--- a/windwatts-ui/src/components/resultPane/BiasCorrectedResultsCard.tsx
+++ b/windwatts-ui/src/components/resultPane/BiasCorrectedResultsCard.tsx
@@ -137,9 +137,9 @@ export const BiasCorrectedTiles = memo(() => {
         <Typography variant="h6" sx={{ fontWeight: 700 }}>
           {convertOutput(
             Number(
-              productionData?.energy_production?.[
-              KEY_AVERAGE_YEAR
-              ]?.[KEY_KWH_PRODUCED] || 0
+              productionData?.energy_production?.[KEY_AVERAGE_YEAR]?.[
+                KEY_KWH_PRODUCED
+              ] || 0
             ),
             units.output
           ).replace(/\s\w+$/, "")}

--- a/windwatts-ui/src/components/resultPane/BiasCorrectedResultsCard.tsx
+++ b/windwatts-ui/src/components/resultPane/BiasCorrectedResultsCard.tsx
@@ -1,5 +1,5 @@
 import { memo, useContext } from "react";
-import { Box, Paper, Typography } from "@mui/material";
+import { Box, Paper, Typography, Skeleton } from "@mui/material";
 import { UnitsContext } from "../../providers/UnitsContext";
 import { SettingsContext } from "../../providers/SettingsContext";
 import { useBiasCorrectedTilesData } from "../../hooks";
@@ -53,11 +53,28 @@ export const BiasCorrectedTiles = memo(() => {
           gap: 2,
         }}
       >
-        <Paper sx={{ p: 2 }} elevation={2}>
-          <Typography variant="body2" color="text.secondary">
-            Loading…
-          </Typography>
-        </Paper>
+        {[0, 1, 2].map((i) => (
+          <Paper key={i} sx={{ p: 2, textAlign: "center" }} elevation={2}>
+            <Skeleton
+              variant="text"
+              width="40%"
+              height={20}
+              sx={{ mx: "auto" }}
+            />
+            <Skeleton
+              variant="text"
+              width="70%"
+              height={36}
+              sx={{ mx: "auto", mt: 1 }}
+            />
+            <Skeleton
+              variant="text"
+              width="30%"
+              height={16}
+              sx={{ mx: "auto" }}
+            />
+          </Paper>
+        ))}
       </Box>
     );
   }

--- a/windwatts-ui/src/components/resultPane/BiasCorrectedResultsCard.tsx
+++ b/windwatts-ui/src/components/resultPane/BiasCorrectedResultsCard.tsx
@@ -4,6 +4,7 @@ import { UnitsContext } from "../../providers/UnitsContext";
 import { SettingsContext } from "../../providers/SettingsContext";
 import { useBiasCorrectedTilesData } from "../../hooks";
 import { convertWindspeed, convertOutput, getWindResource } from "../../utils";
+import { KEY_AVERAGE_YEAR, KEY_KWH_PRODUCED } from "../../constants";
 
 // Compact, card-less variant for embedding in the top row
 export const BiasCorrectedTiles = memo(() => {
@@ -135,7 +136,11 @@ export const BiasCorrectedTiles = memo(() => {
         </Typography>
         <Typography variant="h6" sx={{ fontWeight: 700 }}>
           {convertOutput(
-            Number(productionData?.energy_production || 0),
+            Number(
+              productionData?.energy_production?.[
+              KEY_AVERAGE_YEAR
+              ]?.[KEY_KWH_PRODUCED] || 0
+            ),
             units.output
           ).replace(/\s\w+$/, "")}
         </Typography>

--- a/windwatts-ui/src/components/resultPane/ProductionCard.tsx
+++ b/windwatts-ui/src/components/resultPane/ProductionCard.tsx
@@ -14,6 +14,12 @@ import {
   Skeleton,
 } from "@mui/material";
 import { UnitsContext } from "../../providers/UnitsContext";
+import {
+  KEY_AVERAGE_YEAR,
+  KEY_HIGHEST_YEAR,
+  KEY_KWH_PRODUCED,
+  KEY_LOWEST_YEAR,
+} from "../../constants";
 import { ProductionDataTable } from "./ProductionDataTable";
 import { convertOutput, getOutOfBoundsMessage } from "../../utils";
 import { ExpandMore, ExpandLess } from "@mui/icons-material";
@@ -214,17 +220,23 @@ export const ProductionCard = memo(() => {
   }
 
   // Data loaded successfully
-  const summaryData = productionData.summary_avg_energy_production;
-  const avgProduction = summaryData?.["Average year"]?.["kWh produced"] || 0;
-  const lowProduction = summaryData?.["Lowest year"]?.["kWh produced"] || 0;
-  const highProduction = summaryData?.["Highest year"]?.["kWh produced"] || 0;
+  const summaryData = productionData?.summary_avg_energy_production;
+  const avgProduction = Number(
+    summaryData?.[KEY_AVERAGE_YEAR]?.[KEY_KWH_PRODUCED] || 0
+  );
+  const lowProduction = Number(
+    summaryData?.[KEY_LOWEST_YEAR]?.[KEY_KWH_PRODUCED] || 0
+  );
+  const highProduction = Number(
+    summaryData?.[KEY_HIGHEST_YEAR]?.[KEY_KWH_PRODUCED] || 0
+  );
 
   // Determine data type and set up variables
   // may need something more robust here if we add more data types
   const monthlyData = "monthly_avg_energy_production" in productionData;
   const tableData = monthlyData
     ? productionData.monthly_avg_energy_production
-    : productionData.yearly_avg_energy_production;
+    : productionData?.yearly_avg_energy_production;
 
   const detailsLabel = monthlyData
     ? "Monthly Production Details"

--- a/windwatts-ui/src/components/resultPane/ProductionDataTable.tsx
+++ b/windwatts-ui/src/components/resultPane/ProductionDataTable.tsx
@@ -11,6 +11,11 @@ import {
 import { useContext } from "react";
 import { UnitsContext } from "../../providers/UnitsContext";
 import { convertOutput, convertWindspeed } from "../../utils";
+import {
+  KEY_AVG_WIND_SPEED,
+  KEY_KWH_PRODUCED,
+  MONTH_NAMES,
+} from "../../constants";
 
 interface ProductionDataTableProps {
   title: string;
@@ -30,20 +35,7 @@ const ProductionDisplay = ({
   // Define order based on time unit
   const timeOrder =
     timeUnit === "month"
-      ? [
-          "Jan",
-          "Feb",
-          "Mar",
-          "Apr",
-          "May",
-          "Jun",
-          "Jul",
-          "Aug",
-          "Sep",
-          "Oct",
-          "Nov",
-          "Dec",
-        ]
+      ? MONTH_NAMES
       : Object.keys(data).sort((a, b) => parseInt(a) - parseInt(b));
 
   const sortedData = timeOrder
@@ -52,7 +44,7 @@ const ProductionDisplay = ({
 
   // Calculate min/max for better wind speed bar scaling
   const windSpeeds = sortedData.map(({ values }) =>
-    Number(values["Average wind speed (m/s)"])
+    Number(values[KEY_AVG_WIND_SPEED])
   );
   const minWindSpeed = Math.min(...windSpeeds);
   const maxWindSpeed = Math.max(...windSpeeds);
@@ -60,7 +52,7 @@ const ProductionDisplay = ({
 
   // Calculate max production for energy bar scaling
   const productions = sortedData.map(({ values }) =>
-    Number(values["kWh produced"])
+    Number(values[KEY_KWH_PRODUCED])
   );
   const maxProduction = Math.max(...productions);
 
@@ -88,8 +80,8 @@ const ProductionDisplay = ({
         </TableHead>
         <TableBody>
           {sortedData.map(({ time, values }) => {
-            const windSpeed = Number(values["Average wind speed (m/s)"]);
-            const production = Number(values["kWh produced"]);
+            const windSpeed = Number(values[KEY_AVG_WIND_SPEED]);
+            const production = Number(values[KEY_KWH_PRODUCED]);
 
             // Min/max scaling: smallest bar = 30%, largest bar = 100%, interpolate between
             const windSpeedPercentage =

--- a/windwatts-ui/src/components/settings/LossAssumptionSettings.tsx
+++ b/windwatts-ui/src/components/settings/LossAssumptionSettings.tsx
@@ -1,0 +1,85 @@
+import { useContext, useMemo, useState } from "react";
+import {
+  Box,
+  TextField,
+  Typography,
+  InputAdornment,
+  Switch,
+  FormControlLabel,
+} from "@mui/material";
+import { SettingsContext } from "../../providers/SettingsContext";
+
+export function LossAssumptionSettings() {
+  const { lossAssumptionPercent, setLossAssumptionPercent } =
+    useContext(SettingsContext);
+
+  const [inputValue, setInputValue] = useState<string>(
+    String(lossAssumptionPercent)
+  );
+
+  const percent = useMemo(() => {
+    const parsed = Number(inputValue);
+    if (Number.isNaN(parsed)) return lossAssumptionPercent;
+    return Math.max(0, Math.min(100, Math.round(parsed)));
+  }, [inputValue, lossAssumptionPercent]);
+
+  const handleCommit = (value: number) => {
+    setLossAssumptionPercent(value);
+    setInputValue(String(value));
+  };
+
+  const enabled = percent > 0;
+
+  const handleToggle = (on: boolean) => {
+    if (on) {
+      handleCommit(17);
+    } else {
+      handleCommit(0);
+    }
+  };
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        Loss Assumption
+      </Typography>
+      <Typography variant="body1" gutterBottom>
+        Reduce displayed energy results by an assumed percent loss.
+      </Typography>
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+        <FormControlLabel
+          sx={{ flexShrink: 0, mr: 1 }}
+          control={
+            <Switch
+              checked={enabled}
+              onChange={(e) => handleToggle(e.target.checked)}
+            />
+          }
+          label="Enable"
+        />
+        <TextField
+          size="small"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onBlur={() => handleCommit(percent)}
+          inputProps={{
+            inputMode: "numeric",
+            pattern: "[0-9]*",
+            min: 0,
+            max: 100,
+          }}
+          fullWidth
+          sx={{ flex: 1, minWidth: 0 }}
+          label="Loss"
+          disabled={!enabled}
+          InputProps={{
+            endAdornment: <InputAdornment position="end">%</InputAdornment>,
+          }}
+        />
+      </Box>
+      <Typography variant="caption" color="text.secondary">
+        Stored internally as a factor of {((100 - percent) / 100).toFixed(2)}.
+      </Typography>
+    </Box>
+  );
+}

--- a/windwatts-ui/src/components/settings/LossAssumptionSettings.tsx
+++ b/windwatts-ui/src/components/settings/LossAssumptionSettings.tsx
@@ -43,8 +43,8 @@ export function LossAssumptionSettings() {
       <Typography variant="h6" gutterBottom>
         Loss Assumption
       </Typography>
-      <Typography variant="body1" gutterBottom>
-        Reduce displayed energy results by an assumed percent loss.
+      <Typography variant="body2" mb={2}>
+        Set an energy percent loss (17% recommended).
       </Typography>
       <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
         <FormControlLabel
@@ -77,9 +77,6 @@ export function LossAssumptionSettings() {
           }}
         />
       </Box>
-      <Typography variant="caption" color="text.secondary">
-        Stored internally as a factor of {((100 - percent) / 100).toFixed(2)}.
-      </Typography>
     </Box>
   );
 }

--- a/windwatts-ui/src/components/settings/Settings.tsx
+++ b/windwatts-ui/src/components/settings/Settings.tsx
@@ -14,6 +14,7 @@ import { useContext, useState } from "react";
 import { SettingsContext } from "../../providers/SettingsContext";
 // import { ModelSettings } from "./ModelSettings";
 import { PowerCurveSettings } from "./PowerCurveSettings";
+import { LossAssumptionSettings } from "./LossAssumptionSettings";
 import { HubHeightSettings } from "./HubHeightSettings";
 import {
   SETTINGS_MODAL_WIDTH,
@@ -96,6 +97,7 @@ export const Settings = () => {
         >
           <HubHeightSettings />
           <PowerCurveSettings />
+          <LossAssumptionSettings />
           <UnitsSettings />
           {/* <ModelSettings /> */}
 

--- a/windwatts-ui/src/constants/dataKeys.ts
+++ b/windwatts-ui/src/constants/dataKeys.ts
@@ -1,0 +1,6 @@
+// Keys used in API payloads for production and windspeed tables
+export const KEY_KWH_PRODUCED = "kWh produced";
+export const KEY_AVG_WIND_SPEED = "Average wind speed (m/s)";
+export const KEY_AVERAGE_YEAR = "Average year";
+export const KEY_LOWEST_YEAR = "Lowest year";
+export const KEY_HIGHEST_YEAR = "Highest year";

--- a/windwatts-ui/src/constants/index.ts
+++ b/windwatts-ui/src/constants/index.ts
@@ -4,3 +4,4 @@ export * from "./powerCurves";
 export * from "./ui";
 export * from "./dataModelInfo";
 export * from "./hubSettings";
+export * from "./dataKeys";

--- a/windwatts-ui/src/constants/ui.ts
+++ b/windwatts-ui/src/constants/ui.ts
@@ -18,3 +18,18 @@ export const INITIAL_MAP_ZOOM = 12; // Only used for initial zoom, then user con
 
 // Breakpoints (should match theme breakpoints)
 export const MOBILE_BREAKPOINT = "sm";
+
+export const MONTH_NAMES = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];

--- a/windwatts-ui/src/hooks/index.ts
+++ b/windwatts-ui/src/hooks/index.ts
@@ -7,3 +7,4 @@ export { useProductionData } from "./useProductionData";
 export { useBiasCorrectedTilesData } from "./useBiasCorrectedTilesData";
 export { useToggle } from "./useToggle";
 export { useWindData } from "./useWindData";
+export { useLossAdjustedProductionData } from "./useLossAdjustedProductionData";

--- a/windwatts-ui/src/hooks/useLossAdjustedProductionData.ts
+++ b/windwatts-ui/src/hooks/useLossAdjustedProductionData.ts
@@ -1,0 +1,80 @@
+import { useMemo } from "react";
+import { applyLoss } from "../utils";
+import {
+  KEY_AVERAGE_YEAR,
+  KEY_HIGHEST_YEAR,
+  KEY_KWH_PRODUCED,
+  KEY_LOWEST_YEAR,
+  KEY_AVG_WIND_SPEED,
+} from "../constants";
+
+type EnergyRow = Record<string, string | number | null>;
+type ProductionApiData = {
+  summary_avg_energy_production?: Record<string, EnergyRow>;
+  monthly_avg_energy_production?: Record<string, EnergyRow>;
+  yearly_avg_energy_production?: Record<string, EnergyRow>;
+};
+
+export function useLossAdjustedProductionData(
+  data: ProductionApiData | undefined,
+  lossAssumptionFactor: number
+): ProductionApiData | undefined {
+  return useMemo(() => {
+    if (!data) return undefined;
+    try {
+      const clone: ProductionApiData = structuredClone
+        ? structuredClone(data)
+        : JSON.parse(JSON.stringify(data));
+
+      const summary = clone.summary_avg_energy_production;
+      if (summary) {
+        [KEY_AVERAGE_YEAR, KEY_LOWEST_YEAR, KEY_HIGHEST_YEAR].forEach(
+          (k: string) => {
+            const row = summary[k] as EnergyRow | undefined;
+            if (row && row[KEY_KWH_PRODUCED] != null) {
+              row[KEY_KWH_PRODUCED] = applyLoss(
+                Number(row[KEY_KWH_PRODUCED]),
+                lossAssumptionFactor,
+                { mode: "floor" }
+              );
+            }
+          }
+        );
+      }
+
+      const coerceAndApply = (obj: Record<string, EnergyRow>) => {
+        Object.keys(obj).forEach((key) => {
+          const row = obj[key];
+          if (!row) return;
+          if (row[KEY_KWH_PRODUCED] != null) {
+            row[KEY_KWH_PRODUCED] = applyLoss(
+              Number(row[KEY_KWH_PRODUCED]),
+              lossAssumptionFactor,
+              { mode: "floor" }
+            );
+          }
+          if (row[KEY_AVG_WIND_SPEED] != null) {
+            const ws = Number(row[KEY_AVG_WIND_SPEED]);
+            if (Number.isFinite(ws)) {
+              row[KEY_AVG_WIND_SPEED] = applyLoss(ws, lossAssumptionFactor, {
+                mode: "floor",
+                digits: 2,
+              });
+            }
+          }
+        });
+      };
+
+      if (clone.monthly_avg_energy_production) {
+        coerceAndApply(clone.monthly_avg_energy_production);
+      }
+      if (clone.yearly_avg_energy_production) {
+        coerceAndApply(clone.yearly_avg_energy_production);
+      }
+
+      return clone;
+    } catch {
+      return data;
+    }
+  }, [data, lossAssumptionFactor]);
+}

--- a/windwatts-ui/src/hooks/useLossAdjustedProductionData.ts
+++ b/windwatts-ui/src/hooks/useLossAdjustedProductionData.ts
@@ -5,7 +5,6 @@ import {
   KEY_HIGHEST_YEAR,
   KEY_KWH_PRODUCED,
   KEY_LOWEST_YEAR,
-  KEY_AVG_WIND_SPEED,
 } from "../constants";
 
 type EnergyRow = Record<string, string | number | null>;
@@ -52,15 +51,6 @@ export function useLossAdjustedProductionData(
               lossAssumptionFactor,
               { mode: "floor" }
             );
-          }
-          if (row[KEY_AVG_WIND_SPEED] != null) {
-            const ws = Number(row[KEY_AVG_WIND_SPEED]);
-            if (Number.isFinite(ws)) {
-              row[KEY_AVG_WIND_SPEED] = applyLoss(ws, lossAssumptionFactor, {
-                mode: "floor",
-                digits: 2,
-              });
-            }
           }
         });
       };

--- a/windwatts-ui/src/hooks/useProductionData.ts
+++ b/windwatts-ui/src/hooks/useProductionData.ts
@@ -3,6 +3,7 @@ import useSWR from "swr";
 import { SettingsContext } from "../providers/SettingsContext";
 import { getEnergyProduction } from "../services/api";
 import { isOutOfBounds } from "../utils";
+import { useLossAdjustedProductionData } from ".";
 
 export const useProductionData = () => {
   const {
@@ -10,6 +11,7 @@ export const useProductionData = () => {
     hubHeight,
     powerCurve,
     preferredModel: dataModel,
+    lossAssumptionFactor,
   } = useContext(SettingsContext);
   const { lat, lng } = currentPosition || {};
   const outOfBounds =
@@ -49,8 +51,13 @@ export const useProductionData = () => {
     }
   );
 
+  const productionDataWithLoss = useLossAdjustedProductionData(
+    data,
+    lossAssumptionFactor
+  );
+
   return {
-    productionData: data,
+    productionData: productionDataWithLoss ?? data,
     isLoading,
     error,
     hasData: !!data,

--- a/windwatts-ui/src/hooks/useWindData.ts
+++ b/windwatts-ui/src/hooks/useWindData.ts
@@ -2,7 +2,7 @@ import { useContext, useMemo } from "react";
 import useSWR from "swr";
 import { SettingsContext } from "../providers/SettingsContext";
 import { getWindspeedByLatLong } from "../services/api";
-import { applyLoss, isOutOfBounds } from "../utils";
+import { isOutOfBounds } from "../utils";
 
 export const useWindData = () => {
   const {
@@ -38,28 +38,8 @@ export const useWindData = () => {
     }
   );
 
-  const { lossAssumptionFactor } = useContext(SettingsContext);
-  const windData = useMemo(() => {
-    if (!data) return data;
-    try {
-      const clone = structuredClone
-        ? structuredClone(data)
-        : JSON.parse(JSON.stringify(data));
-      if (clone.global_avg != null) {
-        clone.global_avg = applyLoss(
-          Number(clone.global_avg),
-          lossAssumptionFactor,
-          { mode: "floor", digits: 2 }
-        );
-      }
-      return clone;
-    } catch {
-      return data;
-    }
-  }, [data, lossAssumptionFactor]);
-
   return {
-    windData,
+    windData: data,
     isLoading,
     error,
     hasData: !!data,

--- a/windwatts-ui/src/hooks/useWindData.ts
+++ b/windwatts-ui/src/hooks/useWindData.ts
@@ -2,7 +2,7 @@ import { useContext, useMemo } from "react";
 import useSWR from "swr";
 import { SettingsContext } from "../providers/SettingsContext";
 import { getWindspeedByLatLong } from "../services/api";
-import { isOutOfBounds } from "../utils";
+import { applyLoss, isOutOfBounds } from "../utils";
 
 export const useWindData = () => {
   const {
@@ -38,8 +38,28 @@ export const useWindData = () => {
     }
   );
 
+  const { lossAssumptionFactor } = useContext(SettingsContext);
+  const windData = useMemo(() => {
+    if (!data) return data;
+    try {
+      const clone = structuredClone
+        ? structuredClone(data)
+        : JSON.parse(JSON.stringify(data));
+      if (clone.global_avg != null) {
+        clone.global_avg = applyLoss(
+          Number(clone.global_avg),
+          lossAssumptionFactor,
+          { mode: "floor", digits: 2 }
+        );
+      }
+      return clone;
+    } catch {
+      return data;
+    }
+  }, [data, lossAssumptionFactor]);
+
   return {
-    windData: data,
+    windData,
     isLoading,
     error,
     hasData: !!data,

--- a/windwatts-ui/src/providers/SettingsContext.tsx
+++ b/windwatts-ui/src/providers/SettingsContext.tsx
@@ -14,9 +14,13 @@ export interface StoredSettings {
   powerCurve: string;
   preferredModel: DataModel;
   biasCorrection: boolean;
+  // Loss assumption factor stored as inverse percentage (e.g., 0.83 for 17%)
+  lossAssumptionFactor: number;
 }
 
 export interface Settings extends StoredSettings {
+  // Derived value for convenience (0-100)
+  lossAssumptionPercent: number;
   toggleSettings: () => void;
   toggleResults: () => void;
   setCurrentPosition: (position: CurrentPosition) => void;
@@ -24,6 +28,8 @@ export interface Settings extends StoredSettings {
   setPowerCurve: (curve: string) => void;
   setPreferredModel: (preferredModel: DataModel) => void;
   setBiasCorrection: (biasCorrection: boolean) => void;
+  setLossAssumptionFactor: (factor: number) => void;
+  setLossAssumptionPercent: (percent: number) => void;
 }
 
 export const defaultValues: StoredSettings = {
@@ -34,10 +40,12 @@ export const defaultValues: StoredSettings = {
   powerCurve: "nrel-reference-100kW", // default power curve
   preferredModel: "era5", // default to era5 model
   biasCorrection: false,
+  lossAssumptionFactor: 0.83, // default to 17% loss
 };
 
 export const SettingsContext = createContext<Settings>({
   ...defaultValues,
+  lossAssumptionPercent: 17,
   toggleSettings: () => {},
   toggleResults: () => {},
   setCurrentPosition: () => {},
@@ -45,4 +53,6 @@ export const SettingsContext = createContext<Settings>({
   setPowerCurve: () => {},
   setPreferredModel: () => {},
   setBiasCorrection: () => {},
+  setLossAssumptionFactor: () => {},
+  setLossAssumptionPercent: () => {},
 });

--- a/windwatts-ui/src/providers/SettingsProvider.tsx
+++ b/windwatts-ui/src/providers/SettingsProvider.tsx
@@ -7,6 +7,7 @@ import {
   StoredSettings,
 } from "./SettingsContext";
 import { DataModel } from "../types";
+import { percentToFactor } from "../utils";
 
 export function SettingsProvider({ children }: { children: React.ReactNode }) {
   // Use the useLocalStorage hook to manage settings
@@ -62,9 +63,7 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
 
   const setLossAssumptionPercent = useCallback(
     (percent: number) => {
-      const num = Number(percent);
-      const clampedPercent = Math.max(0, Math.min(100, isNaN(num) ? 0 : num));
-      const factor = (100 - clampedPercent) / 100;
+      const factor = percentToFactor(percent);
       setLossAssumptionFactor(factor);
     },
     [setLossAssumptionFactor]

--- a/windwatts-ui/src/providers/SettingsProvider.tsx
+++ b/windwatts-ui/src/providers/SettingsProvider.tsx
@@ -51,6 +51,25 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     [setSettings]
   );
 
+  // Loss assumption: stored as factor (0-1). Default to 0.83 if missing
+  const setLossAssumptionFactor = useCallback(
+    (factor: number) => {
+      const clamped = Math.max(0, Math.min(1, Number(factor)));
+      setSettings((current) => ({ ...current, lossAssumptionFactor: clamped }));
+    },
+    [setSettings]
+  );
+
+  const setLossAssumptionPercent = useCallback(
+    (percent: number) => {
+      const num = Number(percent);
+      const clampedPercent = Math.max(0, Math.min(100, isNaN(num) ? 0 : num));
+      const factor = (100 - clampedPercent) / 100;
+      setLossAssumptionFactor(factor);
+    },
+    [setLossAssumptionFactor]
+  );
+
   // Toggle functions that update the settings directly
   const toggleSettings = useCallback(() => {
     setSettings((current) => ({
@@ -83,6 +102,16 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
       setPreferredModel,
       biasCorrection: settings.biasCorrection,
       setBiasCorrection,
+      lossAssumptionFactor:
+        settings.lossAssumptionFactor ?? defaultValues.lossAssumptionFactor,
+      lossAssumptionPercent: Math.round(
+        (1 -
+          (settings.lossAssumptionFactor ??
+            defaultValues.lossAssumptionFactor)) *
+          100
+      ),
+      setLossAssumptionFactor,
+      setLossAssumptionPercent,
     }),
     [
       settings.settingsOpen,
@@ -92,6 +121,7 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
       settings.powerCurve,
       settings.preferredModel,
       settings.biasCorrection,
+      settings.lossAssumptionFactor,
       toggleSettings,
       toggleResults,
       setCurrentPosition,
@@ -99,6 +129,8 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
       setPowerCurve,
       setPreferredModel,
       setBiasCorrection,
+      setLossAssumptionFactor,
+      setLossAssumptionPercent,
     ]
   );
 

--- a/windwatts-ui/src/utils/index.test.ts
+++ b/windwatts-ui/src/utils/index.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "vitest";
-import { convertOutput, convertWindspeed, getWindResource } from ".";
+import {
+  convertOutput,
+  convertWindspeed,
+  getWindResource,
+  percentToFactor,
+  applyLoss,
+  roundToSignificantDigits,
+} from ".";
 
 describe("getWindResource", () => {
   test("with high wind speed", () => {
@@ -28,5 +35,63 @@ describe("convertOutput", () => {
   });
   test("converts to MWh", () => {
     expect(convertOutput(1000, "MWh")).toBe("1 MWh");
+  });
+});
+
+describe("percentToFactor", () => {
+  test("17% -> 0.83", () => {
+    expect(percentToFactor(17)).toBeCloseTo(0.83, 2);
+  });
+  test("0% -> 1", () => {
+    expect(percentToFactor(0)).toBe(1);
+  });
+  test("100% -> 0", () => {
+    expect(percentToFactor(100)).toBe(0);
+  });
+  test("clamps and handles NaN", () => {
+    // @ts-expect-error testing bad input
+    expect(percentToFactor("abc")).toBe(1);
+    expect(percentToFactor(-10)).toBe(1);
+    expect(percentToFactor(150)).toBe(0);
+  });
+});
+
+describe("applyLoss", () => {
+  test("applies factor correctly", () => {
+    expect(applyLoss(1000, 0.83)).toBeCloseTo(830, 0);
+  });
+  test("clamps factor and handles non-number value", () => {
+    // @ts-expect-error testing bad input
+    expect(applyLoss("abc", 0.9)).toBe(0);
+    expect(applyLoss(1000, 2)).toBe(1000);
+    expect(applyLoss(1000, -1)).toBe(0);
+  });
+  test("rounds to nearest whole when configured", () => {
+    expect(applyLoss(1234.56, 0.83, { mode: "nearest" })).toBe(1025);
+  });
+  test("floors to whole when configured", () => {
+    expect(applyLoss(1234.56, 0.83, { mode: "floor" })).toBe(1024);
+  });
+  test("floors to 2 decimals when configured", () => {
+    expect(applyLoss(2.089, 1, { mode: "floor", digits: 2 })).toBe(2.08);
+  });
+  test("rounds to nearest 1 decimal when configured", () => {
+    expect(applyLoss(123.45, 0.83, { mode: "nearest", digits: 1 })).toBe(102.5);
+  });
+  test("rounds to significant digits when configured", () => {
+    expect(applyLoss(12.345, 0.83, { mode: "sig", digits: 2 })).toBeCloseTo(
+      10,
+      10
+    );
+  });
+});
+
+describe("roundToSignificantDigits", () => {
+  test("handles zeros", () => {
+    expect(roundToSignificantDigits(0, 2)).toBe(0);
+  });
+  test("simple rounding", () => {
+    expect(roundToSignificantDigits(1234.56, 2)).toBe(1200);
+    expect(roundToSignificantDigits(0.012345, 2)).toBe(0.012);
   });
 });

--- a/windwatts-ui/src/utils/index.ts
+++ b/windwatts-ui/src/utils/index.ts
@@ -15,6 +15,56 @@ export const convertOutput = (output = 0, units = "kWh") => {
   return `${formatNumber(value)} ${units}`;
 };
 
+// Loss helpers
+export const percentToFactor = (percent: number): number => {
+  const num = Number(percent);
+  if (!Number.isFinite(num)) return 1;
+  const clamped = Math.max(0, Math.min(100, num));
+  return (100 - clamped) / 100;
+};
+
+export const roundToSignificantDigits = (
+  value: number,
+  significantDigits: number
+): number => {
+  const v = Number(value);
+  const d = Number(significantDigits);
+  if (!Number.isFinite(v) || !Number.isFinite(d) || d <= 0) return 0;
+  if (v === 0) return 0;
+  const power = Math.floor(Math.log10(Math.abs(v)));
+  const scale = Math.pow(10, power - d + 1);
+  return Math.round(v / scale) * scale;
+};
+
+export const applyLoss = (
+  value: number,
+  factor: number,
+  options?: { mode?: "none" | "nearest" | "floor" | "sig"; digits?: number }
+): number => {
+  const v = Number(value);
+  const f = Math.max(0, Math.min(1, Number(factor)));
+  if (!Number.isFinite(v)) return 0;
+  const raw = v * f;
+  if (!options || options.mode === "none") return raw;
+  if (options.mode === "nearest") {
+    const digits = options.digits ?? 0;
+    return Number.isFinite(digits) && digits > 0
+      ? Number(raw.toFixed(digits))
+      : Math.round(raw);
+  }
+  if (options.mode === "floor") {
+    const digits = options.digits ?? 0;
+    if (digits <= 0) return Math.floor(raw);
+    const scale = Math.pow(10, digits);
+    return Math.floor(raw * scale) / scale;
+  }
+  if (options.mode === "sig") {
+    const digits = options.digits ?? 2;
+    return roundToSignificantDigits(raw, digits);
+  }
+  return raw;
+};
+
 /**
  * Simple number formatting function. Only handles NUMBER types currently.
  *


### PR DESCRIPTION
# Loss Assumption

This code adds loss assumption to the app. The setting can be turned on/off, and configured 0-100 (percentages). It's stored internally as a factor (inverse of the percentage entered) and used to transform the data returned from the API endpoints prior to being displayed in the app (this was chosen so as to not interfere with unit conversion logic that happens post api call).

#### Loss Assumption Off

<img width="1338" height="845" alt="image" src="https://github.com/user-attachments/assets/c1714c9b-f073-4416-ad7f-f60db31825c1" />

#### Loss Assumption On

<img width="1339" height="840" alt="image" src="https://github.com/user-attachments/assets/333426e6-93e1-4ce1-a9db-8fdacdef4973" />
