### PR TITLE
make-smoothing-switchable-bw-datasets

### DIFF
--- a/windwatts-api/app/data_fetchers/athena_data_fetcher.py
+++ b/windwatts-api/app/data_fetchers/athena_data_fetcher.py
@@ -1,5 +1,5 @@
 from .abstract_data_fetcher import AbstractDataFetcher
-from windwatts_data import WindwattsWTKClient, WindwattsERA5Client
+from windwatts_data import WindwattsWTKClient, WindwattsERA5Client, WindwattsEnsembleClient
 
 class AthenaDataFetcher(AbstractDataFetcher):
     def __init__(self, athena_config: str, source_key: str):
@@ -18,9 +18,12 @@ class AthenaDataFetcher(AbstractDataFetcher):
         if self.base_type == 'wtk':
             print(f"Initializing WTK Client with Source Key: {self.source_key}")
             self.client = WindwattsWTKClient(config_path=athena_config, source_key = self.source_key) # source_key  "wtk"
-        elif self.base_type == 'era5' or self.base_type == 'ensemble':
+        elif self.base_type == 'era5':
             print(f"Initializing ERA5 Client with Source Key: {self.source_key}")
             self.client = WindwattsERA5Client(config_path=athena_config, source_key = self.source_key) # source_key  "era5" or "era5_bc"
+        elif self.base_type == 'ensemble':
+            print(f"Initializing Ensemble Client with Source Key: {self.source_key}")
+            self.client = WindwattsEnsembleClient(config_path=athena_config, source_key = self.source_key) # source_key  "ensemble"
         else:
             raise ValueError(f"Unsupported base dataset: {self.base_type}")
 


### PR DESCRIPTION
- Made using SWI smoothing configurable between different dataset types using a dict instance var in PowerCurveManager class called schema_swi_prefs.
- Since ensemble data is not related to ERA5 anymore and it required non smoothing calculation. Creating a seperate client class on package level made sense. (WindwattsEnsembleClient) as we go forward we dont know how different the ensemble model going to be as we work with it and not required to change WindwattsERA5Client again and again.
- New Package version to test ensemble - 1.0.3.1