### PR TITLE
fix timeseries download  bug for wtk-timeseries

### DIFF
--- a/windwatts-api/app/controllers/wind_data_controller.py
+++ b/windwatts-api/app/controllers/wind_data_controller.py
@@ -12,7 +12,7 @@ from app.data_fetchers.s3_data_fetcher import S3DataFetcher
 from app.data_fetchers.athena_data_fetcher import AthenaDataFetcher
 from app.data_fetchers.data_fetcher_router import DataFetcherRouter
 from app.utils.data_fetcher_utils import format_coordinate, chunker
-from app.utils.validation import validate_model, validate_limit
+from app.utils.validation import validate_model_exists, validate_limit
 from app.utils.wind_data_core import (
     get_windspeed_core,
     get_production_core,
@@ -134,7 +134,7 @@ def get_windspeed(
     """
     try:
         # Catch invalid model before core function call
-        model = validate_model(model)
+        model = validate_model_exists(model)
 
         # Use default source if not provided
         if source is None:
@@ -203,7 +203,7 @@ def get_production(
     """
     try:
         # Catch invalid model before core function call
-        model = validate_model(model)
+        model = validate_model_exists(model)
 
         # Backward compatibility for 'powercurve'
         turbine = turbine or powercurve
@@ -336,7 +336,7 @@ def get_grid_points(
     - **limit**: Number of nearest points to return (1-4)
     """
     try:
-        model = validate_model(model)
+        model = validate_model_exists(model)
 
         # Grid lookup only available via athena
         # Use athena fetcher for the specified model
@@ -415,7 +415,7 @@ def get_model_info(
     - **model**: Data model (era5-quantiles, wtk-timeseries, ensemble-quantiles)
     """
     try:
-        model = validate_model(model)
+        model = validate_model_exists(model)
         config = MODEL_CONFIG[model]
         schema = config["schema"]
         temporal_config = TEMPORAL_SCHEMAS[schema]

--- a/windwatts-api/app/utils/validation.py
+++ b/windwatts-api/app/utils/validation.py
@@ -8,7 +8,7 @@ from fastapi import HTTPException
 from app.config.model_config import MODEL_CONFIG, TEMPORAL_SCHEMAS
 
 
-def validate_model(model: str) -> str:
+def validate_model_exists(model: str) -> str:
     """Validate model parameter"""
     if model not in MODEL_CONFIG:
         raise HTTPException(
@@ -199,7 +199,7 @@ def validate_years(years: list[int], model: str) -> list[int]:
         )
     return years
 
-def validate_model_for_timeseries(model: str) -> None:
+def validate_model_for_timeseries(model: str) -> str:
     """Validation that model supports timeseries downloads"""
     model_schema_cfg = TEMPORAL_SCHEMAS[MODEL_CONFIG[model]["schema"]]
     if not model_schema_cfg['period_type'].get('timeseries'):
@@ -207,3 +207,4 @@ def validate_model_for_timeseries(model: str) -> None:
             status_code=400,
             detail=f"Model '{model}' does not support timeseries downloads."
         )
+    return model

--- a/windwatts-api/app/utils/wind_data_core.py
+++ b/windwatts-api/app/utils/wind_data_core.py
@@ -16,7 +16,7 @@ from app.utils.validation import (
     validate_lat,
     validate_lng,
     validate_height,
-    validate_model,
+    validate_model_exists,
     validate_source,
     validate_period_type,
     validate_powercurve,
@@ -54,7 +54,7 @@ def get_windspeed_core(
     """
     lat = validate_lat(model, lat)
     lng = validate_lng(model, lng)
-    model = validate_model(model)
+    model = validate_model_exists(model)
     height = validate_height(model, height)
     source = validate_source(model, source)
     period = validate_period_type(model, period, "windspeed")
@@ -96,7 +96,7 @@ def get_production_core(
     """
     lat = validate_lat(model, lat)
     lng = validate_lng(model, lng)
-    model = validate_model(model)
+    model = validate_model_exists(model)
     height = validate_height(model, height)
     powercurve = validate_powercurve(powercurve)
     source = validate_source(model, source)
@@ -212,8 +212,8 @@ def get_timeseries_core(
     Returns:
         str or pd.DataFrame: CSV content as string or DataFrame
     """
-    model = validate_model(model)
-    validate_model_for_timeseries(model)
+    model = validate_model_exists(model)
+    model = validate_model_for_timeseries(model)
     source = validate_source(model, source)
     period = validate_period_type(model, period, "timeseries")
 


### PR DESCRIPTION
fix #223 
added validate_timeseries_model in validation.py to check if the model's schema is full_hourly or not

---

update: 
The wtk dataset isn't a normal timeseries, it is just year and hour, and cannot be converted to YYYYMM, YYYY-MM-DD and HH, timeseries. The change is to exclude it through the model validation for timeseries endpoints. In the future, we might provide a new endpoint to download the raw data files for this dataset.

---
 initial idea for the fix of the time-series download endpoint bug for data model - "wtk-timeseries" 
 - in model config include hourly as period for timeseries. even though wtk-timeseries is not exactly hourly it is aggregated by **MMHH** so maybe the period can be **aggregrated-mohr** itself. But for now its **hourly** acting as default and only valid period since we are not doing any aggregation like monthly on it unlike era5-timeseries since it has full time column.
 - for wtk-timeseries we dont have a time column(which has year in it or seperate year column) so there isn't a way to identify which year does each df belongs to when appending into frames in s3 data fetcher for each key built. So came up with the idea to use keys itself to append year column to each df when downloading from s3. [**key_year_map**]
 - since wtk-timeseries has 2 sources one is athena for wind estimates and s3 for timeseries direct download from s3 we needed to make **source** in MODEL_CONFIG to a list called **sources** so it can have ["s3" , "athena"]. this is helpful in future to if we want models to support athena for fast compute and s3 for file downloads ( less cost).
 - finally a small change in timeseries_core based on schema to prevent key error df[time] when model isnt fullhourly to skip that parsing and aggregration in case of other schemas.