### PR TITLE
v2.2.3-beta

### DIFF
--- a/windwatts-ui/package.json
+++ b/windwatts-ui/package.json
@@ -42,9 +42,9 @@
     "terser": "^5.43.1",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.1.12",
+    "vite": "6.4.1",
     "vite-plugin-svgr": "^4.5.0",
-    "vitest": "^4.0.3"
+    "vitest": "3.2.4"
   },
   "engines": {
     "node": ">=22.14.0"


### PR DESCRIPTION
EEROR: CICD failure due to yarn - vite version conflict
RESOLUTION: temporarily downgrade vite version, long term migration from yarn v1 to npm/ pnpm