### PR TITLE
api doc typo fix

### DIFF
--- a/windwatts-api/app/controllers/wind_data_controller.py
+++ b/windwatts-api/app/controllers/wind_data_controller.py
@@ -175,7 +175,7 @@ def get_production(
     lng: float = Query(..., description="Longitude of the location"),
     height: int = Query(..., description="Height in meters"),
     turbine: Optional[str] = Query(
-        None, description="Turbine model identifier (e.g., nrl-reference-100kW)"
+        None, description="Turbine model identifier (e.g., nlr-reference-100kW)"
     ),
     powercurve: Optional[str] = Query(
         None,
@@ -411,7 +411,7 @@ def get_model_info(
     - Supported time periods
     - Available years for timeseries downloads
     - Available heights
-    - Grid information (model’s geographic coverage and spatial-temporal resolution)
+    - Grid information (model's geographic coverage and spatial-temporal resolution)
     - Links & References
 
     - **model**: Data model (era5-quantiles, wtk-timeseries, ensemble-quantiles)

--- a/windwatts-api/app/main.py
+++ b/windwatts-api/app/main.py
@@ -29,7 +29,7 @@ app = FastAPI(
         - `/v1/{model}/windspeed` - Wind speed data
         - `/v1/{model}/production` - Energy production estimates
         - `/v1/{model}/timeseries` - Raw timeseries downloads
-        - Supports models: `era5`, `wtk`, `ensemble`
+        - Supports models: `era5-quantiles`, `era5-timeseries`, `wtk-timeseries`, `ensemble-quantiles`
 
         **Legacy**: Model-specific endpoints (deprecated)
         - `/wtk/*` - WTK-specific endpoints


### PR DESCRIPTION
- Fix typo (e.g., nrl-reference-100kW) in api doc
- update model references.